### PR TITLE
[Done] Fix [ rbd_simple_big ] workunit for RHEL 8

### DIFF
--- a/qa/workunits/rbd/simple_big.sh
+++ b/qa/workunits/rbd/simple_big.sh
@@ -2,7 +2,7 @@
 
 mb=100000
 
-rbd create foo --size $mb
+rbd create foo --size $mb --image-feature layering
 DEV=$(sudo rbd map foo)
 dd if=/dev/zero of=$DEV bs=1M count=$mb
 dd if=$DEV of=/dev/null bs=1M count=$mb


### PR DESCRIPTION
Pass log:
http://pulpito.ceph.redhat.com/julpark-2020-03-29_20:42:00-krbd:rbd-nomount-nautilus-distro-basic-argo/
