### PR TITLE
qa/workunits/rdb/krbd_fallocate.sh: force python3 and fix parameter to rbd create

### DIFF
--- a/qa/workunits/rbd/krbd_fallocate.sh
+++ b/qa/workunits/rbd/krbd_fallocate.sh
@@ -115,7 +115,7 @@ assert_zeroes 0
 # unaligned blkdev_issue_discard
 allocate
 py_blkdiscard $((OBJECT_SIZE / 2))
-assert_zeroes_unaligned 1
+assert_zeroes_unaligned $NUM_OBJECTS
 
 # unaligned blkdev_issue_zeroout w/ BLKDEV_ZERO_NOUNMAP
 allocate

--- a/qa/workunits/rbd/krbd_fallocate.sh
+++ b/qa/workunits/rbd/krbd_fallocate.sh
@@ -115,7 +115,7 @@ assert_zeroes 0
 # unaligned blkdev_issue_discard
 allocate
 py_blkdiscard $((OBJECT_SIZE / 2))
-assert_zeroes_unaligned $NUM_OBJECTS
+assert_zeroes_unaligned 1
 
 # unaligned blkdev_issue_zeroout w/ BLKDEV_ZERO_NOUNMAP
 allocate

--- a/qa/workunits/rbd/krbd_fallocate.sh
+++ b/qa/workunits/rbd/krbd_fallocate.sh
@@ -82,13 +82,13 @@ IMAGE_NAME="fallocate-test"
 
 rbd create --size 200 $IMAGE_NAME
 
-IMAGE_SIZE=$(rbd info --format=json $IMAGE_NAME | python -c 'import sys, json; print json.load(sys.stdin)["size"]')
-OBJECT_SIZE=$(rbd info --format=json $IMAGE_NAME | python -c 'import sys, json; print json.load(sys.stdin)["object_size"]')
+IMAGE_SIZE=$(rbd info --format=json $IMAGE_NAME | python3 -c 'import sys, json; print( json.load(sys.stdin)["size"])')
+OBJECT_SIZE=$(rbd info --format=json $IMAGE_NAME | python3 -c 'import sys, json; print( json.load(sys.stdin)["object_size"])')
 NUM_OBJECTS=$((IMAGE_SIZE / OBJECT_SIZE))
 [[ $((IMAGE_SIZE % OBJECT_SIZE)) -eq 0 ]]
 
 IMAGE_ID="$(rbd info --format=json $IMAGE_NAME |
-    python -c "import sys, json; print json.load(sys.stdin)['block_name_prefix'].split('.')[1]")"
+    python3 -c "import sys, json; print(json.load(sys.stdin)['block_name_prefix'].split('.')[1])")"
 
 DEV=$(sudo rbd map $IMAGE_NAME)
 

--- a/qa/workunits/rbd/krbd_fallocate.sh
+++ b/qa/workunits/rbd/krbd_fallocate.sh
@@ -11,7 +11,7 @@ set -ex
 function py_blkdiscard() {
     local offset=$1
 
-    python <<EOF
+    python3 <<EOF
 import fcntl, struct
 BLKDISCARD = 0x1277
 with open('$DEV', 'w') as dev:

--- a/qa/workunits/rbd/krbd_fallocate.sh
+++ b/qa/workunits/rbd/krbd_fallocate.sh
@@ -24,7 +24,7 @@ function py_fallocate() {
     local mode=$1
     local offset=$2
 
-    python <<EOF
+    python3 <<EOF
 import os, ctypes, ctypes.util
 FALLOC_FL_KEEP_SIZE = 0x01
 FALLOC_FL_PUNCH_HOLE = 0x02

--- a/qa/workunits/rbd/krbd_fallocate.sh
+++ b/qa/workunits/rbd/krbd_fallocate.sh
@@ -80,7 +80,7 @@ EOF
 
 IMAGE_NAME="fallocate-test"
 
-rbd create --size 200 $IMAGE_NAME
+rbd create --size 200 $IMAGE_NAME --image-feature layering
 
 IMAGE_SIZE=$(rbd info --format=json $IMAGE_NAME | python3 -c 'import sys, json; print( json.load(sys.stdin)["size"])')
 OBJECT_SIZE=$(rbd info --format=json $IMAGE_NAME | python3 -c 'import sys, json; print( json.load(sys.stdin)["object_size"])')


### PR DESCRIPTION
RHEL 8 Pass log:
http://pulpito.ceph.redhat.com/julpark-2020-03-29_22:28:36-krbd:rbd-nomount-nautilus-distro-basic-argo/

Signed-off-by: julpark-rh <julpark@redhat.com>
