### PR TITLE
[Done] Fix [krbd exclusive option] workunit for RHEL 8

### DIFF
--- a/qa/workunits/rbd/krbd_exclusive_option.sh
+++ b/qa/workunits/rbd/krbd_exclusive_option.sh
@@ -24,10 +24,10 @@ function assert_locked() {
 
     local actual
     actual="$(rados -p rbd --format=json lock info rbd_header.$IMAGE_ID rbd_lock |
-        python -m json.tool)"
+        python3 -m json.tool --sort-keys)"
 
     local expected
-    expected="$(cat <<EOF | python -m json.tool
+    expected="$(cat <<EOF |  -m json.tool --sort-keys
 {
     "lockers": [
         {
@@ -56,10 +56,10 @@ function assert_unlocked() {
 SYSFS_DIR="/sys/bus/rbd/devices"
 IMAGE_NAME="exclusive-option-test"
 
-rbd create --size 1 --image-feature '' $IMAGE_NAME
+rbd create --size 1 --image-feature '' $IMAGE_NAME layering
 
 IMAGE_ID="$(rbd info --format=json $IMAGE_NAME |
-    python -c "import sys, json; print json.load(sys.stdin)['block_name_prefix'].split('.')[1]")"
+    python3 -c "import sys, json; print( json.load(sys.stdin)['block_name_prefix'].split('.')[1])")"
 
 DEV=$(sudo rbd map $IMAGE_NAME)
 assert_unlocked

--- a/qa/workunits/rbd/krbd_exclusive_option.sh
+++ b/qa/workunits/rbd/krbd_exclusive_option.sh
@@ -56,7 +56,7 @@ function assert_unlocked() {
 SYSFS_DIR="/sys/bus/rbd/devices"
 IMAGE_NAME="exclusive-option-test"
 
-rbd create --size 1 --image-feature '' $IMAGE_NAME layering
+rbd create --size 1  '' $IMAGE_NAME --image-feature layering
 
 IMAGE_ID="$(rbd info --format=json $IMAGE_NAME |
     python3 -c "import sys, json; print( json.load(sys.stdin)['block_name_prefix'].split('.')[1])")"

--- a/qa/workunits/rbd/krbd_exclusive_option.sh
+++ b/qa/workunits/rbd/krbd_exclusive_option.sh
@@ -56,7 +56,7 @@ function assert_unlocked() {
 SYSFS_DIR="/sys/bus/rbd/devices"
 IMAGE_NAME="exclusive-option-test"
 
-rbd create --size 1  '' $IMAGE_NAME --image-feature layering
+rbd create --size 1 $IMAGE_NAME --image-feature layering
 
 IMAGE_ID="$(rbd info --format=json $IMAGE_NAME |
     python3 -c "import sys, json; print( json.load(sys.stdin)['block_name_prefix'].split('.')[1])")"

--- a/qa/workunits/rbd/krbd_exclusive_option.sh
+++ b/qa/workunits/rbd/krbd_exclusive_option.sh
@@ -27,7 +27,7 @@ function assert_locked() {
         python3 -m json.tool --sort-keys)"
 
     local expected
-    expected="$(cat <<EOF |  -m json.tool --sort-keys
+    expected="$(cat <<EOF |  python3 -m json.tool --sort-keys
 {
     "lockers": [
         {


### PR DESCRIPTION
RHEL 8 Pass Log:
http://pulpito.ceph.redhat.com/julpark-2020-03-30_02:30:09-krbd:rbd-nomount-nautilus-distro-basic-argo/368606/