### PR TITLE
[Done] Fix [rbd_map_snapshot_io] workunit for RHEL 8

### DIFF
--- a/qa/workunits/rbd/map-snapshot-io.sh
+++ b/qa/workunits/rbd/map-snapshot-io.sh
@@ -4,7 +4,7 @@
 
 set -ex
 
-rbd create image -s 100
+rbd create image -s 100 --image-feature layering
 DEV=$(sudo rbd map image)
 dd if=/dev/zero of=$DEV oflag=direct count=10
 rbd snap create image@s1


### PR DESCRIPTION
RHEL 8 Pass Log:
http://pulpito.ceph.redhat.com/julpark-2020-03-30_03:26:00-krbd:rbd-nomount-nautilus-distro-basic-argo/368609/