### PR TITLE
qa: removing filestore-xfs.yaml

### DIFF
--- a/qa/suites/krbd/fsx/objectstore/filestore-xfs.yaml
+++ b/qa/suites/krbd/fsx/objectstore/filestore-xfs.yaml
@@ -1,1 +1,0 @@
-.qa/objectstore/filestore-xfs.yaml


### PR DESCRIPTION
Nautilus does not supprt xfs. Removing this file instead of adding the missing file, as per the softlink mentioned in this yaml.
sl: qa/objectstore/filestore-xfs.yaml is missing

Signed-off-by: harishmunjulur <hmunjulu@redhat.com>