### PR TITLE
qa/workunit/rbd/krbd_fallocate.sh: python3 syntax eddited

### DIFF
--- a/qa/workunits/rbd/krbd_fallocate.sh
+++ b/qa/workunits/rbd/krbd_fallocate.sh
@@ -11,7 +11,7 @@ set -ex
 function py_blkdiscard() {
     local offset=$1
 
-    python <<EOF
+    python3 <<EOF
 import fcntl, struct
 BLKDISCARD = 0x1277
 with open('$DEV', 'w') as dev:
@@ -24,7 +24,7 @@ function py_fallocate() {
     local mode=$1
     local offset=$2
 
-    python <<EOF
+    python3 <<EOF
 import os, ctypes, ctypes.util
 FALLOC_FL_KEEP_SIZE = 0x01
 FALLOC_FL_PUNCH_HOLE = 0x02
@@ -82,13 +82,13 @@ IMAGE_NAME="fallocate-test"
 
 rbd create --size 200 $IMAGE_NAME
 
-IMAGE_SIZE=$(rbd info --format=json $IMAGE_NAME | python -c 'import sys, json; print json.load(sys.stdin)["size"]')
-OBJECT_SIZE=$(rbd info --format=json $IMAGE_NAME | python -c 'import sys, json; print json.load(sys.stdin)["object_size"]')
+IMAGE_SIZE=$(rbd info --format=json $IMAGE_NAME |  python3 -c 'import sys, json; print( json.load(sys.stdin)["size"])')
+OBJECT_SIZE=$(rbd info --format=json $IMAGE_NAME | python3 -c 'import sys, json; print( json.load(sys.stdin)["object_size"])')
 NUM_OBJECTS=$((IMAGE_SIZE / OBJECT_SIZE))
 [[ $((IMAGE_SIZE % OBJECT_SIZE)) -eq 0 ]]
 
 IMAGE_ID="$(rbd info --format=json $IMAGE_NAME |
-    python -c "import sys, json; print json.load(sys.stdin)['block_name_prefix'].split('.')[1]")"
+    python3 -c "import sys, json; print(json.load(sys.stdin)['block_name_prefix'].split('.')[1])")"
 
 DEV=$(sudo rbd map $IMAGE_NAME)
 
@@ -112,11 +112,18 @@ allocate
 py_fallocate FALLOC_FL_PUNCH_HOLE\|FALLOC_FL_KEEP_SIZE 0
 assert_zeroes 0
 
+#Checking kernel version since py_blkdiscard works depends on kernel verions
+kernel_version=$(cat /proc/version | awk '{print $3}'| cut -c1)
 # unaligned blkdev_issue_discard
 allocate
 py_blkdiscard $((OBJECT_SIZE / 2))
-assert_zeroes_unaligned $NUM_OBJECTS
+if [ $kernel_version = "4" ]; then
+        assert_zeroes_unaligned 1
+fi
 
+if [ $kernel_version = "5" ]; then
+        assert_zeroes_unligned $NUM_OBJECTS
+fi
 # unaligned blkdev_issue_zeroout w/ BLKDEV_ZERO_NOUNMAP
 allocate
 py_fallocate FALLOC_FL_ZERO_RANGE\|FALLOC_FL_KEEP_SIZE $((OBJECT_SIZE / 2))

--- a/qa/workunits/rbd/krbd_fallocate.sh
+++ b/qa/workunits/rbd/krbd_fallocate.sh
@@ -118,7 +118,7 @@ kernel_version=$(cat /proc/version | awk '{print $3}'| cut -c1)
 allocate
 py_blkdiscard $((OBJECT_SIZE / 2))
 if [ $kernel_version = "4" ]; then
-        assert_zeroes_unaligned 1
+        assert_zeroes_unaligned $NUM_OBJECTS
 fi
 
 if [ $kernel_version = "5" ]; then

--- a/qa/workunits/rbd/krbd_fallocate.sh
+++ b/qa/workunits/rbd/krbd_fallocate.sh
@@ -112,18 +112,11 @@ allocate
 py_fallocate FALLOC_FL_PUNCH_HOLE\|FALLOC_FL_KEEP_SIZE 0
 assert_zeroes 0
 
-#Checking kernel version since py_blkdiscard works depends on kernel verions
-kernel_version=$(cat /proc/version | awk '{print $3}'| cut -c1)
 # unaligned blkdev_issue_discard
 allocate
 py_blkdiscard $((OBJECT_SIZE / 2))
-if [ $kernel_version = "4" ]; then
-        assert_zeroes_unaligned $NUM_OBJECTS
-fi
+assert_zeroes_unaligned $NUM_OBJECTS
 
-if [ $kernel_version = "5" ]; then
-        assert_zeroes_unligned $NUM_OBJECTS
-fi
 # unaligned blkdev_issue_zeroout w/ BLKDEV_ZERO_NOUNMAP
 allocate
 py_fallocate FALLOC_FL_ZERO_RANGE\|FALLOC_FL_KEEP_SIZE $((OBJECT_SIZE / 2))


### PR DESCRIPTION
RHEL 8.1:
http://pulpito.ceph.redhat.com/julpark-2020-05-07_21:20:08-krbd:rbd-nomount-nautilus-distro-basic-clara/