### PR TITLE
qa: changing fio_version='3.18'

### DIFF
--- a/qa/tasks/rbd_fio.py
+++ b/qa/tasks/rbd_fio.py
@@ -127,7 +127,7 @@ def run_fio(remote, config, rbd_test_dir):
 
     formats=[1,2]
     features=[['layering'],['striping'],['exclusive-lock','object-map']]
-    fio_version='2.21'
+    fio_version='3.18'
     if config.get('formats'):
         formats=config['formats']
     if config.get('features'):


### PR DESCRIPTION
Rhel8 does not support fio_version='2.21'.
Signed-off-by: harishmunjulur <harishmunjulur@gmail.com>