### PR TITLE
rgw/system_test: calling python3 scripts from venv after activating

### DIFF
--- a/qa/tasks/rgw_system_test.py
+++ b/qa/tasks/rgw_system_test.py
@@ -101,7 +101,8 @@ def task(ctx, config):
                 'source',
                 'venv/bin/activate',
                 run.Raw(';'),
-                run.Raw('pip3 install boto boto3 names PyYaml ConfigParser'),
+                run.Raw('pip3 install boto boto3 names PyYaml ConfigParser python-swiftclient '
+                        'swiftly simplejson rgwadmin'),
                 run.Raw(';'),
                 'deactivate'])
 
@@ -111,8 +112,13 @@ def task(ctx, config):
         log.info('starting the tests after sleep of 60 secs')
         time.sleep(60)
         remote.run(
-            args=[run.Raw(
-                'sudo venv/bin/python3 %s -c %s ' % (script, config_file))])
+            args=[
+                'source',
+                'venv/bin/activate',
+                run.Raw(';'),
+                run.Raw('python3 {script} -c {config_file}'.format(script=script, config_file=config_file)),
+                run.Raw(';'),
+                'deactivate'])
     try:
         yield
     finally:


### PR DESCRIPTION
calling python script from venv after activating and added packages from requirements.txt

Signed-off-by: rakeshgm <rakeshgm@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
