### PR TITLE
Added exec option in rh-ceph-ansible task and balancer commands on system tests

### DIFF
--- a/qa/suites/system-tests/object/single-site/overrides.yaml
+++ b/qa/suites/system-tests/object/single-site/overrides.yaml
@@ -8,21 +8,13 @@ overrides:
       - ceph balancer mode upmap
       - ceph balancer status
     vars:
-      ceph_stable: true
       ceph_origin: distro
-      ceph_stable_rh_storage: true
       ceph_repository: rhcs
-      ceph_stable_release: nautilus
+      ceph_stable: true
+      ceph_stable_rh_storage: true
+      ceph_test: true
       dashboard_enabled: false
-      osd_scenario: collocated
       journal_size: 1024
       osd_auto_discovery: false
-      ceph_test: true
-      ceph_mgr_modules:
-         - status
-         - restful
-      cephfs_pools:
-        - name: "cephfs_data"
-          pgs: "64"
-        - name: "cephfs_metadata"
-          pgs: "64"
+      osd_objectstore: bluestore
+      osd_scenario: collocated


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Added exec option in rh-ceph-ansible task.
- Added balancer commands on system tests to overcome full OSD issue.
