### PR TITLE
Enabled dashboard in ceph-anisble deployment

### DIFF
--- a/qa/rh/downstream.yaml
+++ b/qa/rh/downstream.yaml
@@ -38,7 +38,6 @@ pkgs:
     - python-rbd
     - python-cephfs
     - rbd-mirror
-
 rhel_repos:
   '7':
     - rhel-7-server-rpms
@@ -49,3 +48,13 @@ rhel_repos:
     - rhel-8-for-x86_64-appstream-rpms
     - rhel-8-for-x86_64-baseos-rpms
     - ansible-2.9-for-rhel-8-x86_64-rpms
+dashboard:
+  '4':
+    dashboard_admin_user: admin
+    dashboard_admin_password: p@ssw0rd
+    grafana_admin_user: admin
+    grafana_admin_password: p@ssw0rd
+    node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1
+    grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+    prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:4.1
+    alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:4.1

--- a/qa/suites/smoke/ceph-ansible/clusters/3-mon-2mds-4-osds.yaml
+++ b/qa/suites/smoke/ceph-ansible/clusters/3-mon-2mds-4-osds.yaml
@@ -17,3 +17,4 @@ roles:
 - [osd.0, osd.1, osd.2]
 - [osd.3, osd.4, osd.5, client.0]
 - [osd.6, osd.7, osd.8]
+- [grafana-server.0]

--- a/qa/suites/smoke/ceph-ansible/clusters/3-mon-3-osds.yaml
+++ b/qa/suites/smoke/ceph-ansible/clusters/3-mon-3-osds.yaml
@@ -17,3 +17,4 @@ roles:
 - [osd.0, osd.1, osd.2]
 - [osd.3, osd.4, osd.5]
 - [osd.6, osd.7, osd.8, client.0]
+- [grafana-server.0]

--- a/qa/suites/smoke/ceph-ansible/clusters/3mons-3mgr-1mds-9osds-2rgws-2clients-dashboard.yaml
+++ b/qa/suites/smoke/ceph-ansible/clusters/3mons-3mgr-1mds-9osds-2rgws-2clients-dashboard.yaml
@@ -1,0 +1,5 @@
+roles:
+- [mon.a, mgr.z, mds.a, osd.1, osd.2, osd.0, client.0, rgw.0]
+- [mon.b, mgr.y, osd.3, osd.4, osd.5, client.1, rgw.1]
+- [mon.c, mgr.x, osd.7, osd.6, osd.8]
+- [grafana-server.0]

--- a/qa/suites/smoke/ceph-ansible/clusters/4-mon-1-mds-3-osds.yaml
+++ b/qa/suites/smoke/ceph-ansible/clusters/4-mon-1-mds-3-osds.yaml
@@ -17,3 +17,4 @@ roles:
 - [mon.d, osd.0, osd.1, osd.2]
 - [osd.3, osd.4, osd.5, client.0]
 - [osd.6, osd.7, osd.8]
+- [grafana-server.0]

--- a/qa/suites/smoke/ceph-ansible/vars/downstream.yaml
+++ b/qa/suites/smoke/ceph-ansible/vars/downstream.yaml
@@ -13,7 +13,8 @@ overrides:
       ceph_stable_rh_storage: true
       ceph_repository: rhcs
       ceph_stable_release: nautilus
-      dashboard_enabled: false
+      dashboard_enabled: true
+      copy_admin_key: true
       osd_scenario: collocated
       journal_size: 1024
       osd_auto_discovery: false

--- a/qa/suites/system-tests/object/single-site/overrides.yaml
+++ b/qa/suites/system-tests/object/single-site/overrides.yaml
@@ -1,3 +1,5 @@
+roles:
+- [grafana-server.0]
 overrides:
   rhceph_ansible:
     exec:
@@ -13,7 +15,8 @@ overrides:
       ceph_stable: true
       ceph_stable_rh_storage: true
       ceph_test: true
-      dashboard_enabled: false
+      dashboard_enabled: true
+      copy_admin_key: true
       journal_size: 1024
       osd_auto_discovery: false
       osd_objectstore: bluestore


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Code changes for enabling dashboard on ceph-ansible module.
- Enabled dashboard  on ceph-ansible smoke test suites. 

Successful test link:
http://pulpito.ceph.redhat.com/sunnagar-2020-10-20_03:26:16-smoke:ceph-ansible-master-distro-basic-clara/